### PR TITLE
Add CCSF_GLOBAL_MESSAGE

### DIFF
--- a/docs/outlook/mapi/mapi-constants.md
+++ b/docs/outlook/mapi/mapi-constants.md
@@ -62,6 +62,7 @@ This section contains constant definitions and class and interface identifiers f
 |CCSF_USE_RTF  <br/> |0x0080  <br/> |
 |CCSF_PLAIN_TEXT_ONLY  <br/> |0x1000  <br/> |
 |CCSF_NO_MSGID  <br/> |0x4000  <br/> |
+|CCSF_GLOBAL_MESSAGE  <br/> |0x00200000  <br/> |
 |E_INVALIDARG  <br/> | *As defined in the Microsoft Windows Software Development Kit (SDK) header file winerror.h*  <br/> |
    
 ### Class identifiers


### PR DESCRIPTION
CCSF_GLOBAL_MESSAGE is mentioned in https://docs.microsoft.com/en-us/office/client-developer/outlook/mapi/iconvertersession-mapitomimestm but its value isn't given.