### PR TITLE
Slightly better workaround for last arg truncation issue

### DIFF
--- a/docs/excel/known-issues-in-excel-xll-development.md
+++ b/docs/excel/known-issues-in-excel-xll-development.md
@@ -26,7 +26,7 @@ When an XLL registers a function or command, Excel creates a new name for the re
   
 ## Argument Description String Truncation in the Function Wizard
 
-The  *pxArgumentHelp1*  parameter and all subsequent parameters of the **xlfRegister** function are optional strings that correspond to the arguments of the XLL function. The Function Wizard displays these to provide help in the argument construction dialog box. Sometimes Excel truncates the string that corresponds to the final argument by one or two characters when displaying it in the dialog box. You can avoid this by adding an additional "empty string" argument as the last argument of your function registration. 
+The  *pxArgumentHelp1*  parameter and all subsequent parameters of the **xlfRegister** function are optional strings that correspond to the arguments of the XLL function. The Function Wizard displays these to provide help in the argument construction dialog box. Sometimes Excel truncates the string that corresponds to the final argument by one or two characters when displaying it in the dialog box. You can avoid this by adding an additional "empty string" as the last "argument help" parameter of your function registration.
   
 ## Binary Name Scope Limitation
 

--- a/docs/excel/known-issues-in-excel-xll-development.md
+++ b/docs/excel/known-issues-in-excel-xll-development.md
@@ -26,7 +26,7 @@ When an XLL registers a function or command, Excel creates a new name for the re
   
 ## Argument Description String Truncation in the Function Wizard
 
-The  *pxArgumentHelp1*  parameter and all subsequent parameters of the **xlfRegister** function are optional strings that correspond to the arguments of the XLL function. The Function Wizard displays these to provide help in the argument construction dialog box. Sometimes Excel truncates the string that corresponds to the final argument by one or two characters when displaying it in the dialog box. You can avoid this by adding one or two spaces to the end of the final string. 
+The  *pxArgumentHelp1*  parameter and all subsequent parameters of the **xlfRegister** function are optional strings that correspond to the arguments of the XLL function. The Function Wizard displays these to provide help in the argument construction dialog box. Sometimes Excel truncates the string that corresponds to the final argument by one or two characters when displaying it in the dialog box. You can avoid this by adding an additional "empty string" argument as the last argument of your function registration. 
   
 ## Binary Name Scope Limitation
 


### PR DESCRIPTION
Even if you add one or two spaces, the '.' character is still truncated. Also, if you have a function with no arguments, then it is the function help that is truncated. I've found that adding an empty string as the last "argument help" parameter of a given function registration is a better workaround. Nothing is truncated, and the '.' character is shown in all cases.