### PR TITLE
Changed a typo in OutlookInspector class

### DIFF
--- a/docs/outlook/pia/how-to-implement-a-wrapper-for-inspectors-and-track-item-level-events-in-each-inspector.md
+++ b/docs/outlook/pia/how-to-implement-a-wrapper-for-inspectors-and-track-item-level-events-in-each-inspector.md
@@ -103,7 +103,7 @@ class OutlookInspector
     // wrapped ContactItem
     private Outlook.ContactItem m_Contact;
     // wrapped TaskItem      
-    private Outlook.ContactItem m_Task;             
+    private Outlook.TaskItem m_Task;             
 
     // OutlookInspector constructor
     public OutlookInspector(Outlook.Inspector inspector)


### PR DESCRIPTION
From.
// wrapped TaskItem      
    private Outlook.ContactItem m_Task;
To
// wrapped TaskItem      
    private Outlook.TaskItem m_Task;