### PR TITLE
Add info to page title & H1 for relevance

### DIFF
--- a/docs/excel/excel-home.md
+++ b/docs/excel/excel-home.md
@@ -1,5 +1,5 @@
 ---
-title: "Excel"
+title: "Develop solutions and customize Excel"
 ms.date: 10/03/2018
 ms.audience: Developer
 ms.topic: overview
@@ -8,7 +8,7 @@ description: "Find how-to content, sample code, SDK and API documentation, VBA r
 localization_priority: Priority
 ---
 
-# Excel
+# Develop solutions and customize Excel
 
 Find how-to content, sample code, SDK and API documentation, VBA references, training, and technical articles for developing solutions and customizing Excel.
   


### PR DESCRIPTION
This page has a lot of traffic, but many people immediately leave the page because the page title and H1 don't have enough information about the page intent. I've recommend a light edit for better search and on-page relevance. - Carolyn Gronlund, Advanced Analytics doc manager & SEO