### PR TITLE
Update pidtagservicedllname-canonical-property.md

### DIFF
--- a/docs/outlook/mapi/pidtagservicedllname-canonical-property.md
+++ b/docs/outlook/mapi/pidtagservicedllname-canonical-property.md
@@ -35,7 +35,7 @@ Contains the filename of the DLL containing the message service provider entry p
 
 When the entry point function name appears in the **PR_SERVICE_ENTRY_NAME** ([PidTagServiceEntryName](pidtagserviceentryname-canonical-property.md)) method, it indicates that the entry point exists.
   
-MAPI uses a DLL file naming convention. The base filename contains up to six characters that uniquely identify the DLL. MAPI appends the string 32 to the base DLL name to identify the version that runs on 32-bit platforms. For example, when the name MAPI.DLL is specified, MAPI constructs the name MAPI32.DLL to represent the corresponding 32-bit version of the DLL.
+MAPI uses a DLL file naming convention. It appends the string 32 to the base DLL name to identify the version that runs on 32-bit platforms. For example, when the name MAPI.DLL is specified, MAPI constructs the name MAPI32.DLL to represent the corresponding 32-bit version of the DLL.
   
 These properties should specify the base name. MAPI appends the string 32 as appropriate. Including the string 32 as part of these properties result in an error.
   


### PR DESCRIPTION
Via CI 100773, this request is from Outlook PG to delete the sentence "The base filename contains up to six characters that uniquely identify the DLL." because MAPI does not limit the filename to 6 characters and having this incorrect limit in place may cause issues for some users especially now that MAPI is being more restrictive about the DLLs that it will load. Would you please approve this update? Thanks!