### PR TITLE
Update pidtagproviderdllname-canonical-property.md

### DIFF
--- a/docs/outlook/mapi/pidtagproviderdllname-canonical-property.md
+++ b/docs/outlook/mapi/pidtagproviderdllname-canonical-property.md
@@ -33,7 +33,7 @@ Contains the base file name of the MAPI service provider dynamic-link library (D
    
 ## Remarks
 
-MAPI uses a DLL file naming convention. The base filename contains up to six characters that uniquely identify the DLL. MAPI appends the string 32 to the base DLL name to identify the version that runs on 32-bit platforms. For example, when the name MAPI.DLL is specified, MAPI constructs the name MAPI32.DLL to represent the corresponding 32-bit version of the DLL.
+MAPI uses a DLL file naming convention. MAPI appends the string 32 to the base DLL name to identify the version that runs on 32-bit platforms. For example, when the name MAPI.DLL is specified, MAPI constructs the name MAPI32.DLL to represent the corresponding 32-bit version of the DLL.
   
 These properties should specify the base name. MAPI appends the string 32 as appropriate. Including the string 32 as part of this property results in an error.
   


### PR DESCRIPTION
Via CI 100773, this request is from Outlook PG to delete the sentence "The base filename contains up to six characters that uniquely identify the DLL." because MAPI does not limit the filename to 6 characters and having this incorrect limit in place may cause issues for some users especially now that MAPI is being more restrictive about the DLLs that it will load. Would you please approve this update? Thanks!