### PR TITLE
Add OLK_ACCOUNT_NO_FLAGS to list of constants

### DIFF
--- a/docs/outlook/auxiliary/constants-account-management-api.md
+++ b/docs/outlook/auxiliary/constants-account-management-api.md
@@ -32,6 +32,7 @@ This topic contains constant definitions, class identifiers, and interface ident
 |E_OLK_PARAM_NOT_SUPPORTED  <br/> |0x800C8003  <br/> |
 |E_OLK_PROP_READ_ONLY  <br/> |0x800C800D  <br/> |
 |E_OLK_REGISTRY  <br/> |0x800C8001  <br/> |
+|OLK_ACCOUNT_NO_FLAGS  <br/> |0x00000004  <br/> |
 |The following constants beginning with ENCRYPT_ are used by the [PROP_SMTP_SECURE_CONNECTION](prop_smtp_secure_connection.md) property to specify the type of encrypted connection.  <br/> ||
 |ENCRYPT_CONN_AUTO  <br/> |3  <br/> |
 |ENCRYPT_CONN_NO_SECURITY  <br/> |0  <br/> |

--- a/docs/outlook/auxiliary/constants-account-management-api.md
+++ b/docs/outlook/auxiliary/constants-account-management-api.md
@@ -44,7 +44,6 @@ This topic contains constant definitions, class identifiers, and interface ident
 |NOTIFY_ACCT_DELETED  <br/> |3  <br/> |
 |NOTIFY_ACCT_ORDER_CHANGED  <br/> |4  <br/> |
 |NOTIFY_ACCT_PREDELETED  <br/> |5  <br/> |
-|OLK_ACCOUNT_NO_FLAGS  <br/> |0  <br/> |
 |S_OK  <br/> | *As defined in the Windows SDK header file winerror.h.*  <br/> |
 |S_FALSE  <br/> | *As defined in the Windows SDK header file winerror.h.*  <br/> |
 |SECURE_FLAG  <br/> |0x8000  <br/> |


### PR DESCRIPTION
OLK_ACCOUNT_NO_FLAGS is documented in https://docs.microsoft.com/en-us/office/client-developer/outlook/auxiliary/iolkaccountmanager-init and its corresponding value should be listed here