### PR TITLE
[XLL] Fix information regarding the returned value

### DIFF
--- a/docs/excel/xleventregister.md
+++ b/docs/excel/xleventregister.md
@@ -41,7 +41,7 @@ Starting in Excel 2010, Excel supports the following events:
    
 ## Property value/Return value
 
-If successful, returns **TRUE** (**xltypeBool**). If unsuccessful, returns **FALSE**.
+If successful, pxRes (**xltypeInt**) has a value > 0. If unsuccessful, pxRes ==0.
   
 ## See also
 


### PR DESCRIPTION
According to my tests, the return value (pxRes) has a type xltypeInt and is superior to 0 if success, and equal to zero if it fails. The return value  (ireturnvalue) of the function itself (int ireturnvalue=Excel12(..))  is always zero.