### PR TITLE
Typo "** *srcAngle* **"→"***srcAngle***"

### DIFF
--- a/docs/visio/angletoloc-function.md
+++ b/docs/visio/angletoloc-function.md
@@ -20,7 +20,7 @@ Returns a transformed angle in the destination shape's local coordinate system. 
   
 ## Syntax
 
-ANGLETOLOC(** *srcAngle* **, ** *srcRef* **, ** *dstRef* ** ) 
+ANGLETOLOC(***srcAngle***, ***srcRef***, ***dstRef*** ) 
   
 ### Parameters
 


### PR DESCRIPTION
https://docs.microsoft.com/en-us/office/client-developer/visio/angletoloc-function