### PR TITLE
Typo "** *srcAngle* **"→"***srcAngle***"

### DIFF
--- a/docs/visio/angletopar-function.md
+++ b/docs/visio/angletopar-function.md
@@ -20,7 +20,7 @@ Returns a transformed angle in the destination shape's parent coordinate system.
   
 ## Syntax
 
-ANGLETOPAR(** *srcAngle* **, ** *srcRef* **, ** *dstRef* ** ) 
+ANGLETOPAR(***srcAngle***, ***srcRef***, ***dstRef*** ) 
   
 ### Parameters
 


### PR DESCRIPTION
https://docs.microsoft.com/en-us/office/client-developer/visio/angletopar-function