### PR TITLE
Update lookuprecord-data-block.md

### DIFF
--- a/docs/access/desktop-database-reference/lookuprecord-data-block.md
+++ b/docs/access/desktop-database-reference/lookuprecord-data-block.md
@@ -57,7 +57,7 @@ The **SetField** action has the following arguments.
 
 ## Remarks
 
-If the criteria specified by the *In* and *Where Condition* arguments specifies more than one record, the **LookupRecord** data block will operate only on the first record.
+If the criteria specified by the *In* and *Where Condition* arguments returns more than one record, the **LookupRecord** data block will operate only on the first record.  In the case that no records match the specified criteria, Access will skip over the set of actions contained within the **LookupRecord** block, as if it had been an **[If](if-then-else-macro-block.md)** macro block expression that evaluated as false.
 
 ## Example
 


### PR DESCRIPTION
I noticed that the **LookupRecord** documentation lacked any description of what occurs when no records match the specified criteria.  I found an answer on Stack Exchange (https://stackoverflow.com/questions/29013731/data-macros-using-default-values-if-lookuprecord-does-not-find-a-match/29029441#29029441), personally validated it in Access 2016, and proposed it here so that it can become part of the official, publicly available Microsoft documentation.  Thank you for your time and consideration.