### PR TITLE
Fix PT_ERROR definition in autocomplete-stream.md

### DIFF
--- a/docs/outlook/mapi/autocomplete-stream.md
+++ b/docs/outlook/mapi/autocomplete-stream.md
@@ -134,6 +134,7 @@ Some properties have no Value Data and only have data in the union. The followin
 |:-----|:-----|
 |PT_I2  <br/> |short int  <br/> |
 |PT_LONG  <br/> |long  <br/> |
+|PT_ERROR  <br/> |long  <br/> |
 |PT_R4  <br/> |float  <br/> |
 |PT_DOUBLE  <br/> |double  <br/> |
 |PT_BOOLEAN  <br/> |short int  <br/> |
@@ -159,13 +160,6 @@ PT_CLSID
 |||
    
 PT_BINARY 
-  
-|**Value Data**|**Number of Bytes**|
-|:-----|:-----|
-|Number of bytes n  <br/> |4  <br/> |
-|Bytes to be interpreted as a byte array  <br/> |n  <br/> |
-   
-PT_ERROR
   
 |**Value Data**|**Number of Bytes**|
 |:-----|:-----|


### PR DESCRIPTION
PT_ERROR is a "32-bit error value"