### PR TITLE
reflect support for oiFeatureFreeBusyIntegration

### DIFF
--- a/docs/shared/integrating-im-applications-with-office.md
+++ b/docs/shared/integrating-im-applications-with-office.md
@@ -305,6 +305,10 @@ The **GetSupportedFeatures** method returns information about the IM features th
 > - **oiFeaturePictures** (2) 
 > - **oiFeatureFreeBusyIntegration**
 > - **oiFeaturePhoneNormalization**
+>
+>  Office 365 version 2011 (and higher) applications ignore following constants in the **OIFeature** enumeration: 
+> - **oiFeaturePictures** (2) 
+> - **oiFeaturePhoneNormalization**
   
 Use the following code example to implement the **GetSupportFeatures** method within the IM client application code. 
   


### PR DESCRIPTION
oiFeatureFreeBusyIntegration in the OIFeature is supported in Outlook for Office 365 version 2011 and higher