### PR TITLE
Add missing examples in filter-property-ado.md

### DIFF
--- a/docs/access/desktop-database-reference/filter-property-ado.md
+++ b/docs/access/desktop-database-reference/filter-property-ado.md
@@ -41,9 +41,11 @@ The criteria string is made up of clauses in the form *FieldName-Operator-Value*
     > [!NOTE]
     > To include single quotation marks (') in the filter Value, use two single quotation marks to represent one. For example, to filter on O'Malley, the criteria string should be "col1 = 'O''Malley'". To include single quotation marks at both the beginning and the end of the filter value, enclose the string with pound signs (#). For example, to filter on '1', the criteria string should be "col1 = #'1'#".
 
-  - There is no precedence between **AND** and **OR**. Clauses can be grouped within parentheses. However, you cannot group clauses joined by an **OR** and then join the group to another clause with an **AND**, like this:
-
-  - Instead, you would construct this filter as
+-   There is no precedence between **AND** and **OR**. Clauses can be grouped within parentheses. However, you cannot group clauses joined by an **OR** and then join the group to another clause with an **AND**, as in the following code snippet:  
+ `(LastName = 'Smith' OR LastName = 'Jones') AND FirstName = 'John'`  
+  
+-   Instead, you would construct this filter as  
+ `(LastName = 'Smith' AND FirstName = 'John') OR (LastName = 'Jones' AND FirstName = 'John')`  
 
   - In a **LIKE** clause, you can use a wildcard at the beginning and end of the pattern (for example, LastName Like '\*mit\*'), or only at the end of the pattern (for example, LastName Like 'Smit\*').
 

--- a/docs/access/desktop-database-reference/filter-property-ado.md
+++ b/docs/access/desktop-database-reference/filter-property-ado.md
@@ -1,4 +1,5 @@
 ---
+description: "Filter Property"
 title: Filter property (ADO)
 TOCTitle: Filter property (ADO)
 ms:assetid: 5abc528a-a6ee-34de-5d44-a3249194b0a0


### PR DESCRIPTION
Added examples on how _not_ to use "OR" and how to do it _instead_. Those examples were introduced in the text but missing. 

As I was looking for this very specific information and found it missing, I was glad to find the answer in [filter property docs of SQL server](https://docs.microsoft.com/en-us/sql/ado/reference/ado-api/filter-property) and copied it over as it applies here as well.