### PR TITLE
Typo "**ADOX.***ObjectName*"→"**ADOX.** *ObjectName*"

### DIFF
--- a/docs/access/desktop-database-reference/source-property-ado-error.md
+++ b/docs/access/desktop-database-reference/source-property-ado-error.md
@@ -22,7 +22,7 @@ Returns a **String** value that indicates the name of an object or application.
 
 ## Remarks
 
-Use the **Source** property on an [Error](error-object-ado.md) object to determine the name of the object or application that originally generated an error. This could be the object's class name or programmatic ID. For errors in ADO, the property value will be **ADODB.***ObjectName*, where *ObjectName* is the name of the object that triggered the error. For ADOX and ADO MD, the value will be **ADOX.***ObjectName* and **ADOMD.***ObjectName,* respectively.
+Use the **Source** property on an [Error](error-object-ado.md) object to determine the name of the object or application that originally generated an error. This could be the object's class name or programmatic ID. For errors in ADO, the property value will be **ADODB.** *ObjectName*, where *ObjectName* is the name of the object that triggered the error. For ADOX and ADO MD, the value will be **ADOX.** *ObjectName* and **ADOMD.** *ObjectName,* respectively.
 
 Based on the error documentation from the **Source**, [Number](number-property-ado.md), and [Description](description-property-ado.md) properties of **Error** objects, you can write code that will handle the error appropriately.
 


### PR DESCRIPTION
https://docs.microsoft.com/en-us/office/client-developer/access/desktop-database-reference/source-property-ado-error