### PR TITLE
LISTMEMBERCOUNT Return incorrect

### DIFF
--- a/docs/visio/listmembercount-function.md
+++ b/docs/visio/listmembercount-function.md
@@ -30,6 +30,6 @@ Integer
   
 ## Remarks
 
-If the shape is not a list container, the LISTMEMBERCOUNT function returns -1.
+If the shape is not a list container, the LISTMEMBERCOUNT function returns 0.
   
 


### PR DESCRIPTION
If the shape is not a list container, the LISTMEMBERCOUNT function returns -1.
should read
If the shape is not a list container, the LISTMEMBERCOUNT function returns 0.