### PR TITLE
change namespaces to reflect actual use in Visio

### DIFF
--- a/docs/visio/schema-mapvisio-xml.md
+++ b/docs/visio/schema-mapvisio-xml.md
@@ -22,7 +22,7 @@ This topic shows the XML schema definition for the Visio 2013 file format.
     Visio VSDX Schema
     Copyright (C) 2013 Microsoft Corporation. All rights reserved.
 -->
-<xsd:schema xmlns:xsd="https://www.w3.org/2001/XMLSchema" targetNamespace="http://schemas.microsoft.com/office/visio/2011/1/core" xmlns="http://schemas.microsoft.com/office/visio/2011/1/core" elementFormDefault="qualified" attributeFormDefault="unqualified">
+<xsd:schema xmlns:xsd="https://www.w3.org/2001/XMLSchema" targetNamespace="http://schemas.microsoft.com/office/visio/2012/main" xmlns="http://schemas.microsoft.com/office/visio/2012/main" elementFormDefault="qualified" attributeFormDefault="unqualified">
     <xsd:annotation>
         <xsd:documentation>
             Permission to copy, display and distribute the contents of this document (the "Specification"), in any medium for any purpose without fee or royalty is hereby granted, provided that you include the following notice on ALL copies of the Specification, or portions thereof, that you make:


### PR DESCRIPTION
The value of the targetNamespace and default ("http://schemas.microsoft.com/office/visio/2011/1/core") does not reflect the namespaces found in Visio documents, which is "http://schemas.microsoft.com/office/visio/2012/main".  Validation does not work without this change.