### PR TITLE
Update tip-cell-controls-section.md

### DIFF
--- a/docs/visio/tip-cell-controls-section.md
+++ b/docs/visio/tip-cell-controls-section.md
@@ -25,7 +25,7 @@ To get a reference to the Tip cell by name from another formula, or from a progr
   
 |||
 |:-----|:-----|
-| Cell name:  <br/> | Controls.  *name*  .Tipwhere Controls.  *name*  is the name of the controls row.  <br/> |
+| Cell name:  <br/> | Controls. *name* .Comment where Controls.  *name*  is the name of the controls row.  <br/> |
    
 To get a reference to the Tip cell by index from a program, use the **CellsSRC** property with the following arguments: 
   

--- a/docs/visio/tip-cell-controls-section.md
+++ b/docs/visio/tip-cell-controls-section.md
@@ -25,7 +25,7 @@ To get a reference to the Tip cell by name from another formula, or from a progr
   
 |||
 |:-----|:-----|
-| Cell name:  <br/> | Controls. *name* .Comment where Controls.  *name*  is the name of the controls row.  <br/> |
+| Cell name:  <br/> | Controls. *name* .Prompt where Controls.  *name*  is the name of the controls row.  <br/> |
    
 To get a reference to the Tip cell by index from a program, use the **CellsSRC** property with the following arguments: 
   


### PR DESCRIPTION
Changed cell name from 'Tip' to 'Comment'.  Although the cell displays as 'Tip' in the ShapeSheet, its api name is 'Comment' (even though its SRC cell indice is 'visCtlTip')

cc @lindalu-MSFT