### PR TITLE
Typo "** Excel12 **"→"**Excel12**"

### DIFF
--- a/docs/excel/functions-in-the-framework-library.md
+++ b/docs/excel/functions-in-the-framework-library.md
@@ -15,7 +15,7 @@ ms.assetid: 7d9a13fd-9a4c-423e-bb08-4a5be57c7905
 
 **Applies to**: Excel 2013 | Office 2013 | Visual Studio 
   
-The Framework Library was created to help make writing XLLs easier. It includes simple functions for managing **XLOPER**/ **XLOPER12** memory, creating temporary **XLOPER**/ **XLOPER12**, robustly calling the Microsoft Excel callback functions (**Excel4**, **Excel4v**, ** Excel12 **, ** Excel12v **) and printing debugging strings on an attached terminal.
+The Framework Library was created to help make writing XLLs easier. It includes simple functions for managing **XLOPER**/ **XLOPER12** memory, creating temporary **XLOPER**/ **XLOPER12**, robustly calling the Microsoft Excel callback functions (**Excel4**, **Excel4v**, **Excel12**, **Excel12v**) and printing debugging strings on an attached terminal.
   
 The functions included in this library help simplify a piece of code that looks like the following.
   


### PR DESCRIPTION
https://docs.microsoft.com/en-us/office/client-developer/excel/functions-in-the-framework-library
https://github.com/MicrosoftDocs/office-developer-client-docs/blob/main/docs/excel/functions-in-the-framework-library.md
#PingMSFTDocs