### PR TITLE
Retire ms.prod: "office365"

### DIFF
--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -47,7 +47,7 @@
       "ms.topic": "conceptual",
       "uhfHeaderId": "MSDocsHeader-Dev_Office",
       "ms.suite": "office",
-      "ms.prod": "office365",
+      "ms.service": "office-365",
       "description": "Office developer client VBA reference"
     },
     "fileMetadata": {


### PR DESCRIPTION
This is a bulk update to replace ms.prod: "office365" with ms.service: "office-365" per ceapex Allow List request: 563840