### PR TITLE
Update create-table-statement-microsoft-access-sql.md

### DIFF
--- a/docs/access/desktop-database-reference/create-table-statement-microsoft-access-sql.md
+++ b/docs/access/desktop-database-reference/create-table-statement-microsoft-access-sql.md
@@ -179,7 +179,7 @@ This example creates a new table called `~~Kitsch'n Sync` that demonstrates all 
                 & ",[Double]                FLOAT" _
                 & ",[Decimal]               DECIMAL(18,5)" _
                 & ",[Currency]              MONEY" _
-                & ",[ShortText]             CHAR" _
+                & ",[ShortText]             VARCHAR" _
                 & ",[LongText]              MEMO" _
                 & ",[PlaceHolder1]          MEMO" _
                 & ",[DateTime]              DATETIME" _


### PR DESCRIPTION
ShortText field can be created preferrably by using VARCHAR type, not CHAR. If CHAR is used, it will pad the field with spaces. Took me long to realize and this documentation wasn't helpful in that regard.