### PR TITLE
Fix a spello in docs/outlook/mapi/constructing-entry-identifiers.md

### DIFF
--- a/docs/outlook/mapi/constructing-entry-identifiers.md
+++ b/docs/outlook/mapi/constructing-entry-identifiers.md
@@ -36,7 +36,7 @@ MAPI_DIM is a constant that is defined in the MapiDefs.h header file.
   
 The first byte of the 4-byte **abFlags** member describes the type and use of the entry identifier and can have the following values: 
   
-- MAPI_NOTRECI — Indicates the entry identifier cannot be used as a recipient on a message.
+- MAPI_NOTRECIP — Indicates the entry identifier cannot be used as a recipient on a message.
     
 - MAPI_NOTRESERVED — Indicates that other users cannot access the entry identifier.
     


### PR DESCRIPTION
Confer with docs/outlook/mapi/entryid.md and/or the Windows SDK (mapidefs.h) to establish that MAPI_NOTRECIP is the right name.