### PR TITLE
PT_LONG is not fully usable with unsigned data

### DIFF
--- a/docs/outlook/mapi/property-types.md
+++ b/docs/outlook/mapi/property-types.md
@@ -27,7 +27,7 @@ The single-value and multiple-value property types that MAPI supports are descri
 |PT_UNSPECIFIED  <br/> |0000  <br/> |Indicates that the property type is unknown. This property type is reserved for use with interface methods. |
 |PT_NULL  <br/> |0001  <br/> |Indicates no property value. This property type is reserved for use with interface methods and is the same as the OLE type VT_NULL. |
 |PT_I2 (PT_MV_I2)  <br/> |0002  <br/> |Signed 16-bit (2-byte) integer. This property type is the same as PT_SHORT (PT_MV_SHORT) and the OLE type VT_I2. |
-|PT_I4 (PT_MV_I4)  <br/> |0003  <br/> |Signed or unsigned 32-bit (4-byte) integer. This property type is the same as PT_LONG (PT_MV_LONG) and the OLE type VT_I4. |
+|PT_I4 (PT_MV_I4)  <br/> |0003  <br/> |Signed 32-bit (4-byte) integer. This property type is the same as PT_LONG (PT_MV_LONG) and the OLE type VT_I4. |
 |PT_FLOAT (PT_MV_FLOAT)  <br/> |0004  <br/> |32-bit (8-byte) floating point value. This property type is the same as PT_R4 (PT_MV_R4) and the OLE type VT_R4. |
 |PT_DOUBLE (PT_MV_DOUBLE)  <br/> |0005  <br/> |64-bit (8-byte) floating point value. This property type is the same as PT_R8 and the OLE types VT_R8 and VT_DOUBLE. |
 |PT_CURRENCY (PT_MV_CURRENCY )  <br/> |0006  <br/> |64-bit (8-byte) integer interpreted as decimal. This property type is compatible with the Microsoft Visual Basic CURRENCY type and is the same as the OLE type VT_CY. |
@@ -35,7 +35,7 @@ The single-value and multiple-value property types that MAPI supports are descri
 |PT_ERROR  <br/> |000A  <br/> |SCODE value; 32-bit (4-byte) unsigned integer. This property type is the same as the OLE type VT_ERROR. |
 |PT_BOOLEAN (PT_MV_12)  <br/> |000B  <br/> |16-bit (2-byte) Boolean value where zero equals **false** and non-zero equals **true**. This property type is the same as the OLE type VT_BOOL. |
 |PT_OBJECT  <br/> |000D  <br/> |Pointer to an object that implements the **IUnknown** interface. This property type is similar to several OLE types such as VT_UNKNOWN. |
-|PT_I8 (PT_MV_I8)  <br/> |0014  <br/> |Signed or unsigned 64-bit (8-byte) integer that uses the **LARGE_INTEGER** structure. This property type is the same as PT_I8 and the OLE type VT_I8. |
+|PT_I8 (PT_MV_I8)  <br/> |0014  <br/> |Signed 64-bit (8-byte) integer that uses the **LARGE_INTEGER** structure. This property type is the same as PT_I8 and the OLE type VT_I8. |
 |PT_STRING8 (PT_MV_STRING8)  <br/> |001E  <br/> |Null-terminated 8-bit (2-byte) character string. This property type is the same as the OLE type VT_LPSTR. |
 |PT_TSTRING (PT_MV_TSTRING)  <br/> |001F  <br/> |Null-terminated 16-bit (2-byte) character string. Properties with this type have the property type reset to PT_UNICODE when compiling with the UNICODE symbol and to PT_STRING8 when not compiling with the UNICODE symbol. This property type is the same as the OLE type VT_LPSTR for resulting PT_STRING8 properties and VT_LPWSTR for PT_UNICODE properties  <br/> |
 |PT_SYSTIME (PT_MV_SYSTIME)  <br/> |0040  <br/> |64-bit (8-byte) integer data and time value in the form of a **FILETIME** structure. This property type is the same as the OLE type VT_FILETIME. |
@@ -48,4 +48,5 @@ The single-value and multiple-value property types that MAPI supports are descri
 > [!NOTE]
 > To determine the Hex value for the multi-valued property type, OR the PT_MV flag (0x00001000) to the Hex value for the property type. For example, the Hex value for PT_MV_UNICODE is 0x101F and the Hex value for PT_MV_BINARY is 0x1102. 
   
-
+MAPI shares the value type numbers with [[OLE variants]](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-oaut/3fe7db9f-5803-4dc4-9d14-5425d3f5461f). However, not all OLE types are specified for MAPI. In particular, unsigned types such as VT_UI4 have no counterpart in MAPI. 
+Comparison of PT_I2/I4/I8 property values, e.g. during the evaluation of [[restrictions]](https://docs.microsoft.com/en-us/office/client-developer/outlook/mapi/spropertyrestriction) (filters), are performed as a signed comparison. 

--- a/docs/outlook/mapi/spropvalue.md
+++ b/docs/outlook/mapi/spropvalue.md
@@ -56,8 +56,8 @@ typedef struct _SPropValue
 |**Property type**|**Value**|**Data type of Value**|
 |:-----|:-----|:-----|
 |PT_I2 or PT_SHORT  <br/> |**i** <br/> |short int  <br/> |
-|PT_I4 or PT_LONG (signed)  <br/> |**l** <br/> |LONG  <br/> |
-|PT_I4 or PT_LONG (unsigned)  <br/> |**ul** <br/> |ULONG  <br/> |
+|PT_I4 or PT_LONG  <br/> |**l** <br/> |LONG  <br/> |
+|-  <br/> |**ul** <br/> |ULONG  <br/> |
 |PT_R4 or PT_FLOAT  <br/> |**flt** <br/> |float  <br/> |
 |PT_R8 or PT_DOUBLE  <br/> |**dbl** <br/> |double  <br/> |
 |PT_BOOLEAN  <br/> |**b** <br/> |unsigned short int  <br/> |
@@ -100,9 +100,10 @@ The type indicates the format for the property's value. MAPI defines constants f
 For a complete list of the valid property ranges for identifiers and property types, see the [Property Identifiers and Types](property-identifiers-and-types.md) appendix. 
   
 The **dwAlignPad** member is used as padding to make sure proper alignment on computers that require 8-byte alignment for 8-byte values. Developers who write code on such computers should use memory allocation routines that allocate the **SPropValue** arrays on 8-byte boundaries. 
-  
-For more information, see [MAPI Property Type Overview](mapi-property-type-overview.md) and [Updating MAPI Properties](updating-mapi-properties.md). 
-  
+
+The ``SPropValue::ul`` member has no corresponding MAPI property type, since OLE's VT_UI4 is not mapped to MAPI. For more information, see [MAPI Property Type Overview](mapi-property-type-overview.md) and [Updating MAPI Properties](updating-mapi-properties.md).
+When the property type of an SPropValue indicates PT_LONG, the active member of the UPV union is generally ``l``, and accessing ``ul`` constitutes undefined behavior per the C standard. 
+
 ## See also
 
 

--- a/docs/outlook/mapi/spropvalue.md
+++ b/docs/outlook/mapi/spropvalue.md
@@ -83,7 +83,7 @@ typedef struct _SPropValue
 |PT_MV_I8  <br/> |**MVli** <br/> |[SLargeIntegerArray](slargeintegerarray.md) <br/> |
 |PT_ERROR  <br/> |**err** <br/> |[SCODE](scode.md) <br/> |
 |PT_NULL or PT_OBJECT  <br/> |**x** <br/> |LONG  <br/> |
-|PT_PTR  <br/> |**lpv** <br/> |VOID \*  <br/> |
+|PT_PTR or PT_FILE_HANDLE  <br/> |**lpv** <br/> |VOID \*  <br/> |
    
 ## Remarks
 


### PR DESCRIPTION
Editorial note:

Many hyperlinks in the existing documents use a `msdn.microsoft.com/library/` hyperlink, but I was unsure how to turn `https://docs.microsoft.com/en-us/office/client-developer/outlook/mapi/spropertyrestriction` into such a library link.