### PR TITLE
MAPI: first character in ASCII is "NUL"

### DIFF
--- a/docs/outlook/mapi/pidlidtodosubordinal-canonical-property.md
+++ b/docs/outlook/mapi/pidlidtodosubordinal-canonical-property.md
@@ -32,7 +32,7 @@ Acts as a tie breaker when the **dispidToDoOrdinalDate** ([PidLidToDoOrdinalDate
    
 ## Remarks
 
-If used, this property must be sorted lexicographically. The component characters of the string must consist of only the numerals zero through nine. This property should be initially set to "5555555". The length of this property must not exceed 254 characters (excluding the terminating NULL character).
+If used, this property must be sorted lexicographically. The component characters of the string must consist of only the numerals zero through nine. This property should be initially set to "5555555". The length of this property must not exceed 254 characters (excluding the terminating null character).
   
 ## Related resources
 

--- a/docs/outlook/mapi/sizeddtbllabel.md
+++ b/docs/outlook/mapi/sizeddtbllabel.md
@@ -33,7 +33,7 @@ SizedDtblLabel (n, u)
 
 _n_
   
-> Length of the label. This includes the ending NULL character. 
+> Length of the label. This includes the ending null character. 
     
 _u_
   


### PR DESCRIPTION
The mnemonic codes for ASCII control characters have *three*-letter codes, not 4LC. The remaining documentation here uses "null character", so be consistent in the following two files as well.
