### PR TITLE
add Office MSO functions docs.

### DIFF
--- a/docs/shared/Office-funciton-MsoFRequireSignedAddins.md
+++ b/docs/shared/Office-funciton-MsoFRequireSignedAddins.md
@@ -1,0 +1,33 @@
+---
+title: "MsoFRequireSignedAddins functions"
+ 
+ 
+manager: lijia
+ms.date: 10/11/2023
+ms.audience: Developer
+ 
+ 
+ms.localizationpriority: low
+ms.assetid: 
+description: "Find information about the MsoFRequireSignedAddins function."
+---
+
+# MsoFRequireSignedAddins function
+
+## Description
+
+This function will check if Office Trust Center requires Application Add-ins to be signed by Trusted Publishers. The function with underscore prefix is used in a 32-bit Windows cdecl calling convention.
+
+```CPP
+BOOL MsoFRequireSignedAddins()
+
+```
+
+```CPP
+BOOL _MsoFRequireSignedAddins()
+
+```
+
+## Return value
+
+Boolean, which represents if Office Trust Center requires Application Add-ins to be signed by Trusted Publishers.

--- a/docs/shared/Office-funciton-MsoFRequireSignedAddins.md
+++ b/docs/shared/Office-funciton-MsoFRequireSignedAddins.md
@@ -31,3 +31,10 @@ BOOL _MsoFRequireSignedAddins()
 ## Return value
 
 Boolean, which represents if Office Trust Center requires Application Add-ins to be signed by Trusted Publishers.
+
+## Requirements
+
+|  |  |
+|---------------------------------|--------------------------------|
+|DLL                              |MSO.DLL                         |
+|Minimum supported application    |Microsoft Office 2010 system    |

--- a/docs/shared/Office-function-MsoFIsFileFromTrustedLocation.md
+++ b/docs/shared/Office-function-MsoFIsFileFromTrustedLocation.md
@@ -1,0 +1,37 @@
+---
+title: "MsoFIsFileFromTrustedLocation function"
+ 
+ 
+manager: lijia
+ms.date: 10/11/2023
+ms.audience: Developer
+ 
+ 
+ms.localizationpriority: low
+ms.assetid: 
+description: "Find information about the MsoFIsFileFromTrustedLocation funciton."
+---
+
+# MsoFIsFileFromTrustedLocation function
+
+## Description
+
+This function will check if the given file is from some trusted location or not. The function with underscore prefix is used in a 32-bit Windows cdecl calling convention.
+
+```CPP
+BOOL MsoFIsFileFromTrustedLocation(const WCHAR* wzPath) 
+
+```
+
+```CPP
+BOOL _MsoFIsFileFromTrustedLocation(const WCHAR* wzPath) 
+
+```
+
+## Return value
+
+Boolean, which represents if the given file is from some trusted location.
+
+## Remarks
+
+A trusted location is where to store a file when you don’t want that file to be checked by the Office Trust Center.

--- a/docs/shared/Office-function-MsoFIsFileFromTrustedLocation.md
+++ b/docs/shared/Office-function-MsoFIsFileFromTrustedLocation.md
@@ -35,3 +35,10 @@ Boolean, which represents if the given file is from some trusted location.
 ## Remarks
 
 A trusted location is where to store a file when you don’t want that file to be checked by the Office Trust Center.
+
+## Requirements
+
+|  |  |
+|---------------------------------|--------------------------------|
+|DLL                              |MSO.DLL                         |
+|Minimum supported application    |Microsoft Office 2007 system    |

--- a/docs/shared/office-functions-Overview.md
+++ b/docs/shared/office-functions-Overview.md
@@ -1,0 +1,22 @@
+---
+title: "Office functions"
+ 
+ 
+manager: lijia
+ms.date: 10/11/2023
+ms.audience: Developer
+ 
+ 
+ms.localizationpriority: low
+ms.assetid: 
+description: "The overview of public Office MSO functions."
+---
+
+# Office functions
+
+The following functions is provided by the Office 365.
+
+|Function                                                                           |Description                                                                                         |
+|-----------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------|
+|[MsoFRequireSignedAddins](Office-funciton-MsoFRequireSignedAddins.md)              | Check if Office Trust Center requires Application Add-ins to be signed by Trusted Publishers.      |
+|[MsoFIsFileFromTrustedLocation](Office-function-MsoFIsFileFromTrustedLocation.md)  | Check if the given file is from some trusted location or not.                                      |


### PR DESCRIPTION
Adding Office MSO functions in public docs to meet the requirements of the API Usage Standard of the Interoperability Policy.