### PR TITLE
Fix breadcrumbs

### DIFF
--- a/docs/breadcrumb/toc.yml
+++ b/docs/breadcrumb/toc.yml
@@ -3,5 +3,5 @@
   topicHref: /microsoft-365/index
   items:
   - name: Office Add-ins
-    tocHref: /office/dev/add-ins/
+    tocHref: /office/client-developer/
     topicHref: /office/dev/add-ins/index

--- a/docs/breadcrumb/toc.yml
+++ b/docs/breadcrumb/toc.yml
@@ -1,3 +1,7 @@
-- name: Docs
-  tocHref: /
-  topicHref: /
+- name: Microsoft 365
+  tocHref: /office/
+  topicHref: /microsoft-365/index
+  items:
+  - name: Office Add-ins
+    tocHref: /office/dev/add-ins/
+    topicHref: /office/dev/add-ins/index

--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -42,7 +42,6 @@
       "breadcrumb_path": "/office/client-developer/breadcrumb/toc.json",
       "feedback_system": "GitHub",
       "feedback_github_repo": "MicrosoftDocs/office-developer-client-docs",
-      "extendBreadcrumb": true,
       "ms.author": "o365devx",
       "author": "o365devx",
       "ms.topic": "conceptual",


### PR DESCRIPTION
This PR brings breadcrumb implementation into alignment with [platform architecture requirements](https://review.learn.microsoft.com/en-us/help/platform/navigation-overview?branch=main#requirements-for-content-ecosystems). This PR is part of a previously announced batch of breadcrumb fixes across the Learn platform and will be auto-merged if there are no build warnings. This PR may include removing the “extend breadcrumb” feature from any docfx files that are still using it, fixing breadcrumb file references in the docfx file, and rewriting breadcrumb files to match the [approved breadcrumb pattern](https://review.learn.microsoft.com/en-us/help/platform/navigation-breadcrumbs-overview?branch=main#breadcrumbs-in-documentation) for a given product’s documentation. 