### PR TITLE
add metadata (api_name, api_type, api_location) to mso function docs.

### DIFF
--- a/docs/shared/office-function-msofisfilefromtrustedlocation.md
+++ b/docs/shared/office-function-msofisfilefromtrustedlocation.md
@@ -3,6 +3,13 @@ title: "MsoFIsFileFromTrustedLocation function"
 manager: lijia
 ms.date: 10/11/2023
 ms.audience: Developer
+api_name:
+- MsoFIsFileFromTrustedLocation
+- _MsoFIsFileFromTrustedLocation
+api_type:
+- DLLExport
+api_location:
+- mso.dll
 APIPlatform: Office
 ms.localizationpriority: low
 ms.assetid: 

--- a/docs/shared/office-function-msofrequiresignedaddins.md
+++ b/docs/shared/office-function-msofrequiresignedaddins.md
@@ -3,6 +3,13 @@ title: "MsoFRequireSignedAddins function"
 manager: lijia
 ms.date: 10/11/2023
 ms.audience: Developer
+api_name:
+- MsoFRequireSignedAddins
+- _MsoFRequireSignedAddins
+api_type:
+- DLLExport
+api_location:
+- mso.dll
 APIPlatform: Office 
 ms.localizationpriority: low
 ms.assetid: 


### PR DESCRIPTION
In previous PR: https://github.com/MicrosoftDocs/office-developer-client-docs/pull/713, we got [Warning: attribute-reserved], the APILocation, APIType and APIName are reserved for use by Docs. Use "api_name", "api_type" and "api_location" instead.

