### PR TITLE
Adding topic type to API reference documentation previously added

### DIFF
--- a/docs/shared/office-function-msofisfilefromtrustedlocation.md
+++ b/docs/shared/office-function-msofisfilefromtrustedlocation.md
@@ -10,6 +10,9 @@ api_type:
 - DLLExport
 api_location:
 - mso.dll
+topic_type:
+- APIRef
+- kbSyntax
 APIPlatform: Office
 ms.localizationpriority: low
 ms.assetid: 

--- a/docs/shared/office-function-msofrequiresignedaddins.md
+++ b/docs/shared/office-function-msofrequiresignedaddins.md
@@ -10,6 +10,9 @@ api_type:
 - DLLExport
 api_location:
 - mso.dll
+topic_type:
+- APIRef
+- kbSyntax
 APIPlatform: Office 
 ms.localizationpriority: low
 ms.assetid: 


### PR DESCRIPTION
APIScan also requires the tag topic type to be added