### PR TITLE
Implement IUnknown: Make Release method thread-safe

### DIFF
--- a/docs/outlook/mapi/implementing-iunknown-in-c-plus-plus.md
+++ b/docs/outlook/mapi/implementing-iunknown-in-c-plus-plus.md
@@ -50,7 +50,7 @@ ULONG CMyMAPIObject::Release()
 {
     // Decrement the object's internal counter.
     ULONG ulRefCount = InterlockedDecrement(m_cRef);
-    if (0 == m_cRef)
+    if (0 == ulRefCount)
     {
         delete this;
     }


### PR DESCRIPTION
The current impl. is not fully thread-safe, since the `m_cRef` member might have changed by another thread since the `InterlockedDecrement` call on the line above. Suggest to instead use the `InterlockedDecrement` _return-value_ for the ref-count check to avoid this problem.

Examples of implementations already following the same pattern:
* `CComObject::Release` in atlmfc\include\atlcom.h
* `IDocument::Release` in atlmfc\include\atlhandler.h
* `CStringData::Release` in atlmfc\include\atlsimpstr.h
* `_QIThunk::Release` in atlmfc\include\atlbase.h
* [How to implement IUnknown using C++ | Pluralsight](https://www.youtube.com/watch?v=CQoZQR0vCAY)