### PR TITLE
Implement IUnknown: Make AddRef thread-safe

### DIFF
--- a/docs/outlook/mapi/implementing-iunknown-in-c-plus-plus.md
+++ b/docs/outlook/mapi/implementing-iunknown-in-c-plus-plus.md
@@ -43,8 +43,7 @@ The following code example shows how to implement the **AddRef** and **Release**
 ```cpp
 ULONG CMyMAPIObject::AddRef()
 {
-    InterlockedIncrement(m_cRef);
-    return m_cRef;
+    return InterlockedIncrement(m_cRef);
 }
 ULONG CMyMAPIObject::Release()
 {


### PR DESCRIPTION
Follow-up to #764. The current impl. is not fully thread-safe, since the `m_cRef` member might have changed by another thread since the `InterlockedIncrement` call on the line above. Suggest to instead return the `InterlockedIncrement` return-value to avoid this problem.

Examples of implementations already following the same pattern:
* `CComObject::AddRef` in atlmfc\include\atlcom.h
* `IDocument::AddRef` in atlmfc\include\atlhandler.h
* `CStringData::AddRef` in atlmfc\include\atlsimpstr.h
* `_QIThunk::AddRef` in atlmfc\include\atlbase.h
* How to implement IUnknown using C++ | Pluralsight: https://www.youtube.com/watch?v=CQoZQR0vCAY