### PR TITLE
Update sample link for MFCMAPI from Codeplex to GitHub

### DIFF
--- a/docs/outlook/mapi/mfcmapi-as-a-code-sample.md
+++ b/docs/outlook/mapi/mfcmapi-as-a-code-sample.md
@@ -22,7 +22,7 @@ The MFCMAPI sample uses the Messaging API to provide access to MAPI stores throu
    
 ### To download MFCMAPI
   
-1. On the [MFCMAPI](https://codeplex.com/MFCMAPI) page, click the **Source Code** tab. 
+1. On the [MFCMAPI](https://github.com/microsoft/mfcmapi) page, click the **Source Code** tab. 
     
 2. Under **Recent Check-Ins**, click **Download** for the most recent build. 
     


### PR DESCRIPTION
Updated MFCMAPI sample link as CodePlex has been replaced by GitHub