### PR TITLE
Correcting links to MAPI samples that target Deadlinks or Really old external articles to deadlinks

### DIFF
--- a/docs/outlook/mapi/address-book-provider-sample.md
+++ b/docs/outlook/mapi/address-book-provider-sample.md
@@ -20,8 +20,7 @@ ms.assetid: 2ccf1643-5604-4fee-92cc-3d6af00e7f98
   
 This sample supports a single read-only container for display names and email addresses, which are read from a flat binary file. The sample supports one-off templates and all configuration options except the Profile Wizard.
   
-You can download this sample from [Outlook Messaging API (MAPI) Code Samples](https://go.microsoft.com/fwlink/?LinkId=129740
-).
+You can download this sample from [Outlook Messaging API (MAPI) Code Samples](https://github.com/microsoft/Outlook2010CodeSamples).
   
 |Property |Value |
 |:-----|:-----|

--- a/docs/outlook/mapi/downloading-the-outlook-mapi-samples.md
+++ b/docs/outlook/mapi/downloading-the-outlook-mapi-samples.md
@@ -21,7 +21,7 @@ The Microsoft Outlook MAPI samples include an address book provider, a message s
   
  **To download the Sample Address Book Provider**
   
-1. To download the Outlook MAPI samples, click the **Home** tab on the [Outlook Messaging API (MAPI) Code Samples](https://github.com/microsoft/Outlook2010CodeSamples) page. 
+1. To download the Outlook MAPI samples, Visit [Outlook Messaging API (MAPI) Code Samples](https://github.com/microsoft/Outlook2010CodeSamples) page. 
     
 2. On the **Home** tab, click **Click here to download the source for Outlook 2010 MAPI Samples**.
     

--- a/docs/outlook/mapi/downloading-the-outlook-mapi-samples.md
+++ b/docs/outlook/mapi/downloading-the-outlook-mapi-samples.md
@@ -21,7 +21,7 @@ The Microsoft Outlook MAPI samples include an address book provider, a message s
   
  **To download the Sample Address Book Provider**
   
-1. To download the Outlook MAPI samples, click the **Home** tab on the [Outlook Messaging API (MAPI) Code Samples](https://news.softpedia.com/news/Download-Outlook-2010-Messaging-API-MAPI-Code-Samples-117702.shtml) page. 
+1. To download the Outlook MAPI samples, click the **Home** tab on the [Outlook Messaging API (MAPI) Code Samples](https://github.com/microsoft/Outlook2010CodeSamples) page. 
     
 2. On the **Home** tab, click **Click here to download the source for Outlook 2010 MAPI Samples**.
     

--- a/docs/outlook/mapi/downloading-the-outlook-mapi-samples.md
+++ b/docs/outlook/mapi/downloading-the-outlook-mapi-samples.md
@@ -21,7 +21,7 @@ The Microsoft Outlook MAPI samples include an address book provider, a message s
   
  **To download the Sample Address Book Provider**
   
-1. To download the Outlook MAPI samples, Visit [Outlook Messaging API (MAPI) Code Samples](https://github.com/microsoft/Outlook2010CodeSamples) page. 
+1. To download the Outlook MAPI samples, see [Outlook Messaging API (MAPI) Code Samples](https://github.com/microsoft/Outlook2010CodeSamples). 
     
 2. On the **Home** tab, click **Click here to download the source for Outlook 2010 MAPI Samples**.
     

--- a/docs/outlook/mapi/transport-provider-sample.md
+++ b/docs/outlook/mapi/transport-provider-sample.md
@@ -18,7 +18,7 @@ description: "This sample uses files and directories to transmit and receive mes
   
 This sample uses files and directories to transmit and receive messages. It implements and registers a very simple preprocessor that appends a line of text to each outbound message. The sample illustrates how to split message content between Transport Neutral Encapsulation Format (TNEF) and text. It also supports all configuration options (property sheets, wizards, and programmatic configuration) and message options. It does not support the remote transport interfaces.
   
-You can download this sample from [Outlook Messaging API (MAPI) Code Samples](https://go.microsoft.com/fwlink/?LinkId=129740).
+You can download this sample from [Outlook Messaging API (MAPI) Code Samples](https://github.com/microsoft/Outlook2010CodeSamples).
   
 |Property |Value |
 |:-----|:-----|


### PR DESCRIPTION
On
https://learn.microsoft.com/en-us/office/client-developer/outlook/mapi/mapi-service-provider-samples

Says “You can download this sample from [Outlook Messaging API (MAPI) Code Samples](https://go.microsoft.com/fwlink/?LinkId=129740).”
This link should go to https://go.microsoft.com/fwlink/?LinkId=129740 
Seems to be a dead link and lands on MS main page 

Now according to the internet Archive this link should go to 

https://www.codeplex.com/OutlookMAPISample -> 301 -> https://archive.codeplex.com/?p=OutlookMAPISamples

the site now tells us that 
[https://github.com/stephenegriffin/Outlook2007CodeSamples](https://web.archive.org/web/20200722215945mp_/https:/github.com/stephenegriffin/Outlook2007CodeSamples)

	https://github.com/microsoft/Outlook2007CodeSamples/tree/main/SampleTransportProvider/MRXP
(or Outlook2010CodeSamples version) -

same applies for https://github.com/MicrosoftDocs/office-developer-client-docs/blob/main/docs/outlook/mapi/downloading-the-outlook-mapi-samples.md and https://github.com/MicrosoftDocs/office-developer-client-docs/blob/main/docs/outlook/mapi/address-book-provider-sample.md

“Home tab on the [Outlook Messaging API (MAPI) Code Samples] (https://news.softpedia.com/news/Download-Outlook-2010-Messaging-API-MAPI-Code-Samples-117702.shtml)”

This site links to “https://news.softpedia.com/news/Download-Outlook-2010-Messaging-API-MAPI-Code-Samples-117702.shtml” which can be concerning as is outside of Microsoft and refers to https://ol2010mapisamples.codeplex.com/ which is a Dead link.  (as any link to https://codeplex.com/)